### PR TITLE
David Blandon Mena: Fixing localStorage definition issue in navbar component

### DIFF
--- a/components/navbar/navbar.component.tsx
+++ b/components/navbar/navbar.component.tsx
@@ -98,7 +98,7 @@ export const Navbar: React.FC<{ onToggleTheme: () => void }> = ({ onToggleTheme 
     // Default 'returned value' if localStorage is not available
     return (
       <ButtonTheme type="button" icon={
-        <Image src={toggleIconLight} alt="Toggle theme" style={{ width: 30, height: 30 }} />
+        <Image src={toggleIconDark} alt="Toggle theme" style={{ width: 30, height: 30 }} />
       } onClick={onToggleTheme} />
     );
   }

--- a/components/navbar/navbar.component.tsx
+++ b/components/navbar/navbar.component.tsx
@@ -77,20 +77,30 @@ const NavItem = styled.li`
 // Navbar component
 export const Navbar: React.FC<{ onToggleTheme: () => void }> = ({ onToggleTheme }) => {
   function ToggleTheme () {
-    const currentTheme = localStorage.getItem('theme');
-    if (currentTheme === 'light') {
-      return (
-        <ButtonTheme type="button" icon={
-          <Image src={toggleIconDark} alt="Toggle theme" style={{ width: 30, height: 30 }} />
-        } onClick={onToggleTheme} />
-      ) 
-    } else {
-      return (
-        <ButtonTheme type="button" icon={
-          <Image src={toggleIconLight} alt="Toggle theme" style={{ width: 30, height: 30 }} />
-        } onClick={onToggleTheme} />
-      )
+    // Here, we make sure that the localStorage is available
+    if (typeof window !== 'undefined' && window.localStorage) {
+      const currentTheme = localStorage.getItem('theme');
+      if (currentTheme === 'light') {
+        return (
+          <ButtonTheme type="button" icon={
+            <Image src={toggleIconDark} alt="Toggle theme" style={{ width: 30, height: 30 }} />
+          } onClick={onToggleTheme} />
+        ) 
+      } else {
+        return (
+          <ButtonTheme type="button" icon={
+            <Image src={toggleIconLight} alt="Toggle theme" style={{ width: 30, height: 30 }} />
+          } onClick={onToggleTheme} />
+        )
+      }
     }
+
+    // Default 'returned value' if localStorage is not available
+    return (
+      <ButtonTheme type="button" icon={
+        <Image src={toggleIconLight} alt="Toggle theme" style={{ width: 30, height: 30 }} />
+      } onClick={onToggleTheme} />
+    );
   }
 
   return (


### PR DESCRIPTION
Se evidencia un pequeño error en el navbar respecto a la definicion del localStorage, pues se hace necesario crear un valor a retornar para las imagenes del boton de 'toggle theme' en caso de que no este disponible el localStorage.

Se abre y cierra la rama de HOTFIX llamada **"hotfix/navbar-issue"** y el Issue **"David Blandon Mena: Navbar issue because of localStorage definition #29"** creado previamente, al solucionar el problema previamente mencionado.